### PR TITLE
Remove assassins from cell data

### DIFF
--- a/disableAssassins.lua
+++ b/disableAssassins.lua
@@ -30,6 +30,15 @@ Methods.OnObjectSpawn = function(pid, cellDescription)
                 tes3mp.SetObjectMpNum(a) 
                 tes3mp.AddWorldObject() -- Add actor to packet
                 tes3mp.SendObjectDelete() -- Send Delete
+
+                if LoadedCells[cellDescription] ~= nil then
+
+                    local refIndex = "0-" .. a
+                    LoadedCells[cellDescription].data.objectData[refIndex] = nil
+                    tableHelper.removeValue(LoadedCells[cellDescription].data.packets.spawn, refIndex)
+                    tableHelper.removeValue(LoadedCells[cellDescription].data.packets.actorList, refIndex)
+                    LoadedCells[cellDescription]:Save()
+                end
             end
         end
     end

--- a/disableAssassins.lua
+++ b/disableAssassins.lua
@@ -7,33 +7,33 @@ Methods = {}
 
 Methods.OnObjectSpawn = function(pid, cellDescription)
 
-	tes3mp.ReadLastEvent() -- Server doesnt save objects to memory so we only get access to the current packet sent which was "OnObjectSpawn"
+    tes3mp.ReadLastEvent() -- Server doesnt save objects to memory so we only get access to the current packet sent which was "OnObjectSpawn"
 
-	local found = 0
-	local Assassins = {}
-	
-	for i = 0, tes3mp.GetObjectChangesSize() - 1 do -- Loop through all objects sent in packet
-		local refId = tes3mp.GetObjectRefId(i)
-		if string.match(refId, "db_assassin") ~= nil then
-			isObjectAssassin = true
-			Assassins[found] = tes3mp.GetObjectMpNum(i) -- This is how we get the MP num for actors
-			found = found + 1
-		end
-	end
-		
-	if found > 0 then
-		for i,p in pairs(Players) do -- Do this for each player online
-			for index,a in pairs(Assassins) do -- Sometimes more than one assassin spawns
-				tes3mp.InitializeEvent(p.pid)
-				tes3mp.SetEventCell(cellDescription)
-				tes3mp.SetObjectRefNumIndex(0)
-				tes3mp.SetObjectMpNum(a) 
-				tes3mp.AddWorldObject() -- Add actor to packet
-				tes3mp.SendObjectDelete() -- Send Delete
-			end
-		end
-	end
-	
+    local found = 0
+    local Assassins = {}
+
+    for i = 0, tes3mp.GetObjectChangesSize() - 1 do -- Loop through all objects sent in packet
+        local refId = tes3mp.GetObjectRefId(i)
+        if string.match(refId, "db_assassin") ~= nil then
+            isObjectAssassin = true
+            Assassins[found] = tes3mp.GetObjectMpNum(i) -- This is how we get the MP num for actors
+            found = found + 1
+        end
+    end
+
+    if found > 0 then
+        for i,p in pairs(Players) do -- Do this for each player online
+            for index,a in pairs(Assassins) do -- Sometimes more than one assassin spawns
+                tes3mp.InitializeEvent(p.pid)
+                tes3mp.SetEventCell(cellDescription)
+                tes3mp.SetObjectRefNumIndex(0)
+                tes3mp.SetObjectMpNum(a) 
+                tes3mp.AddWorldObject() -- Add actor to packet
+                tes3mp.SendObjectDelete() -- Send Delete
+            end
+        end
+    end
+
 end
 
 return Methods


### PR DESCRIPTION
Previously, spawned assassins got deleted for the players who were on the server at the time via the packet sent by the script, but they remained stored in the cell data and spawned for all players who arrived in the cell afterwards.